### PR TITLE
fusion3: remove languages-full.mk

### DIFF
--- a/fusion3.mk
+++ b/fusion3.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-$(call inherit-product, $(SRC_TARGET_DIR)/product/languages_full.mk)
-
 TARGET_PROVIDES_ADRENO_DRIVER := true
 # inherit from msm8960-common
 $(call inherit-product, device/sony/msm8960-common/msm8960.mk)


### PR DESCRIPTION
languages_full.mk is inherited by locales_full.mk which is inherited by full_base.mk
no need to add this in the device tree

Change-Id: I51138145b2f14fb2176a38fab60464661e108710